### PR TITLE
Fixed Prototype pollution bug on setValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,6 +289,9 @@ var workflow = {
     },
 
     setValue: function (object, path, value) {
+        if (path.includes('__proto__') || path.includes('constructor') || path.includes('prototype')) {
+			return false;
+		}
         var parts = path.split('.');
         path = path.replace(/\[/g, ".").replace(/\]/g, "")
         var part;


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-worksmith

### ⚙️ Description *

worksmith is a purely functional workflow engine, this package is vulnerable to Prototype Pollution via the `setValue` function.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
const worksmith = require('worksmith'); 
worksmith.setValue({}, '__proto__.polluted', true); 
console.log(polluted); // true
```

![image](https://user-images.githubusercontent.com/16708391/92943232-27d4e680-f470-11ea-8618-8744ed8dadc5.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/92943351-49ce6900-f470-11ea-95bd-1831c04b3361.png)



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `path` and no breaking changes are introduced. :)
